### PR TITLE
fix UX bug in telescope picker. resolves #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-> huez.actions will be deprecated in 0.2.1 or next semi-major version. Whichever comes first.
->
-> **PLEASE** use require("huez.api").get_colorscheme() in your Huez configuration in your neovim config instead.
->
-> See updated Setup section.
-
 # 🎨 huez.nvim _(hue ez, hues)_
 
 Color picker using [Telescope](https://github.com/nvim-telescope/telescope.nvim) as a backend.
@@ -31,6 +25,7 @@ Install with your preferred package manager
         -- reccomended, but optional dependency.
         -- Will use vim.ui as a default unless specified otherwise, or a fallback.
         -- Preview does not currently work in vim.ui.
+        -- If using vim.ui, it's also reccomended to use dressing.nvim.
         "nvim-telescope/telescope.nvim",
     },
 },

--- a/lua/huez/actions.lua
+++ b/lua/huez/actions.lua
@@ -1,9 +1,10 @@
 local default_conf = vim.g.huez_config
 local actions = {}
 
--- WARN: This will be deprecated in 0.2.1 or next semi-major version. Whichever comes first
--- PLEASE use require("huez.api").get_colorscheme() in your Huez configuration in your neovim config instead
-
+---@deprecated
+-- This function has been deprecated
+--
+-- Use huez.api instead
 actions.get_colorscheme = function()
   local file, err = io.open(default_conf.file_path, "r")
 

--- a/lua/huez/integrations/telescope/actions.lua
+++ b/lua/huez/integrations/telescope/actions.lua
@@ -1,9 +1,10 @@
 local telescope_actions = require("telescope.actions")
 local telescope_actions_state = require("telescope.actions.state")
+local api = require("huez.api")
 
 local actions = {}
 
----Preview color scheme when going to the next selection
+---Preview color scheme when going to the next selection in the prompt
 ---@param bufnr integer
 actions.next_color = function(bufnr)
   telescope_actions.move_selection_next(bufnr)
@@ -12,12 +13,21 @@ actions.next_color = function(bufnr)
   vim.cmd(cmd)
 end
 
----Preview color scheme when going to the previous selection
+---Preview color scheme when going to the previous selection in the prompt
 ---@param bufnr integer
 actions.prev_color = function(bufnr)
   telescope_actions.move_selection_previous(bufnr)
   local selected = telescope_actions_state.get_selected_entry()
   local cmd = "colorscheme " .. selected[1]
+  vim.cmd(cmd)
+end
+
+-- Resets the colorscheme preview to the previously selected colorscheme if the telescope prompt was quit
+---@param bufnr integer
+actions.reset_if_not_pick = function(bufnr)
+  telescope_actions.close(bufnr)
+  local prev_color = api.get_colorscheme()
+  local cmd = "colorscheme " .. prev_color
   vim.cmd(cmd)
 end
 

--- a/lua/huez/integrations/telescope/adapter.lua
+++ b/lua/huez/integrations/telescope/adapter.lua
@@ -21,6 +21,7 @@ local function pick_colorscheme(opts)
           actions.close(bufnr)
 
           local selection = action_state.get_selected_entry().value
+
           if selection == nil then
             utils._logger("Huez: must choose valid colorscheme", "ERROR")
           else
@@ -34,11 +35,13 @@ local function pick_colorscheme(opts)
         map("i", "<C-p>", adapter_actions.prev_color)
         map("i", "<Up>", adapter_actions.prev_color)
         map("i", "<Down>", adapter_actions.next_color)
+        map("i", "<esc>", adapter_actions.reset_if_not_pick)
 
         map("n", "j", adapter_actions.next_color)
         map("n", "k", adapter_actions.prev_color)
         map("n", "<C-n>", adapter_actions.next_color)
         map("n", "<C-p>", adapter_actions.prev_color)
+        map("n", "<esc>", adapter_actions.reset_if_not_pick)
 
         return true
       end,

--- a/plugin/huez.lua
+++ b/plugin/huez.lua
@@ -14,4 +14,4 @@ local integrations = require("huez.integrations")
 
 vim.api.nvim_create_user_command("Huez", integrations.pick_colorscheme, {})
 
-vim.g.huez_version = "0.2.0"
+vim.g.huez_version = "0.2.1"


### PR DESCRIPTION
Fixes a UX bug in the telescope picker where quitting the prompt will select the currently highlighted theme.

quitting the prompt now resets the colorscheme to whatever the user picked in `.nvim.huez.lua`