### PR TITLE
Set the current color scheme as a preselection in the picker

### DIFF
--- a/lua/huez/integrations/telescope/adapter.lua
+++ b/lua/huez/integrations/telescope/adapter.lua
@@ -12,7 +12,8 @@ local api = require("huez.api")
 local function pick_colorscheme(opts)
   opts = vim.g.huez_config.picker_opts or telescope_themes.get_dropdown()
   local themes = api.filter_default_themes()
-
+  
+  -- set the current color scheme as a preselection in the picker for better UX
   local current_scheme = vim.g.colors_name or "default"
   local default_index = 1
   for i, theme in ipairs(themes) do

--- a/lua/huez/integrations/telescope/adapter.lua
+++ b/lua/huez/integrations/telescope/adapter.lua
@@ -12,6 +12,17 @@ local api = require("huez.api")
 local function pick_colorscheme(opts)
   opts = vim.g.huez_config.picker_opts or telescope_themes.get_dropdown()
   local themes = api.filter_default_themes()
+
+  local current_scheme = vim.g.colors_name or "default"
+  local default_index = 1
+  for i, theme in ipairs(themes) do
+    if theme == current_scheme then
+      default_index = i
+      break
+    end
+  end
+  opts.default_selection_index = default_index
+
   pickers
     .new(opts, {
       prompt_title = "Huez",


### PR DESCRIPTION
This commit sets the current color scheme as a preselection in the picker when it is opened. By automatically selecting the current color scheme, users can quickly identify which scheme is currently in use and make adjustments as needed. This improves the user experience by reducing the need to manually search for the current scheme in the picker's list of options.
