### PR TITLE
Re: Set the current color scheme as a preselection in the picker

### DIFF
--- a/lua/huez/pickers/themes/init.lua
+++ b/lua/huez/pickers/themes/init.lua
@@ -5,8 +5,18 @@ local picker_utils = require("huez.pickers.utils")
 local mappings = require("huez.pickers.themes.mappings")
 local api = require("huez-manager.api")
 
-local function render()
+local function render(opts)
   local themes = api.colorscheme.installed()
+
+  local current_scheme = vim.g.colors_name or "default"
+  local default_index = 1
+  for i, theme in ipairs(themes) do
+    if theme == current_scheme then
+      default_index = i
+      break
+    end
+  end
+  opts.default_selection_index = default_index
 
   picker_utils.picker_builder({
     picker = "themes",
@@ -20,7 +30,7 @@ local function render()
     mappings = function(map)
       mappings.attach(map, actions)
     end,
-  })
+  }, opts)
 end
 
 return {

--- a/lua/huez/pickers/utils.lua
+++ b/lua/huez/pickers/utils.lua
@@ -64,8 +64,9 @@ end
 
 --- Builds a picker
 ---@param opts Huez.PickerBuilder
-M.picker_builder = function(opts)
-  local telescope_opts = M.layout_builder(opts.picker)
+---@param any table
+M.picker_builder = function(opts, any)
+  local telescope_opts = vim.tbl_deep_extend("force", M.layout_builder(opts.picker), any)
   opts.default_action = opts.default_action or function() end
 
   pickers


### PR DESCRIPTION
this was a qol feature of pre 1.0, but forgot to include it in the rewrite, see #15 