### PR TITLE
Added default empty opts for themes picker

### DIFF
--- a/lua/huez/pickers/themes/init.lua
+++ b/lua/huez/pickers/themes/init.lua
@@ -6,34 +6,34 @@ local mappings = require("huez.pickers.themes.mappings")
 local api = require("huez-manager.api")
 
 local function render(opts)
-    opts = opts or {}
-    local themes = api.colorscheme.installed()
+  opts = opts or {}
+  local themes = api.colorscheme.installed()
 
-    local current_scheme = vim.g.colors_name or "default"
-    local default_index = 1
-    for i, theme in ipairs(themes) do
-        if theme == current_scheme then
-            default_index = i
-            break
-        end
+  local current_scheme = vim.g.colors_name or "default"
+  local default_index = 1
+  for i, theme in ipairs(themes) do
+    if theme == current_scheme then
+      default_index = i
+      break
     end
-    opts.default_selection_index = default_index
+  end
+  opts.default_selection_index = default_index
 
-    picker_utils.picker_builder({
-        picker = "themes",
-        prompt_title = "Huez",
-        finder = {
-            results = themes,
-        },
-        default_action = function()
-            actions.save_on_select(telescope_action_state)
-        end,
-        mappings = function(map)
-            mappings.attach(map, actions)
-        end,
-    }, opts)
+  picker_utils.picker_builder({
+    picker = "themes",
+    prompt_title = "Huez",
+    finder = {
+      results = themes,
+    },
+    default_action = function()
+      actions.save_on_select(telescope_action_state)
+    end,
+    mappings = function(map)
+      mappings.attach(map, actions)
+    end,
+  }, opts)
 end
 
 return {
-    render = render,
+  render = render,
 }

--- a/lua/huez/pickers/themes/init.lua
+++ b/lua/huez/pickers/themes/init.lua
@@ -6,33 +6,34 @@ local mappings = require("huez.pickers.themes.mappings")
 local api = require("huez-manager.api")
 
 local function render(opts)
-  local themes = api.colorscheme.installed()
+    opts = opts or {}
+    local themes = api.colorscheme.installed()
 
-  local current_scheme = vim.g.colors_name or "default"
-  local default_index = 1
-  for i, theme in ipairs(themes) do
-    if theme == current_scheme then
-      default_index = i
-      break
+    local current_scheme = vim.g.colors_name or "default"
+    local default_index = 1
+    for i, theme in ipairs(themes) do
+        if theme == current_scheme then
+            default_index = i
+            break
+        end
     end
-  end
-  opts.default_selection_index = default_index
+    opts.default_selection_index = default_index
 
-  picker_utils.picker_builder({
-    picker = "themes",
-    prompt_title = "Huez",
-    finder = {
-      results = themes,
-    },
-    default_action = function()
-      actions.save_on_select(telescope_action_state)
-    end,
-    mappings = function(map)
-      mappings.attach(map, actions)
-    end,
-  }, opts)
+    picker_utils.picker_builder({
+        picker = "themes",
+        prompt_title = "Huez",
+        finder = {
+            results = themes,
+        },
+        default_action = function()
+            actions.save_on_select(telescope_action_state)
+        end,
+        mappings = function(map)
+            mappings.attach(map, actions)
+        end,
+    }, opts)
 end
 
 return {
-  render = render,
+    render = render,
 }


### PR DESCRIPTION
As per the wiki, I had tried setting the following keybind:

```lua
local pickers = require("huez.pickers")

vim.keymap.set("n", "<leader>co", pickers.themes, {})
```

However, pickers.themes takes an `opts` parameter, which is nill when executed above. This caused an error with this keymap. 

This change sets the opts param to `{}` if it is nil.