### PR TITLE
Add preferred background setting configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Huez comes with the following defaults
   suppress_messages = true,
   theme_config_module = nil,
   exclude = { "desert", "evening", "industry", "koehler", "morning", "murphy", "pablo", "peachpuff", "ron", "shine", "slate", "torte", "zellner", "blue", "darkblue", "delek", "quiet", "elflord", "habamax", "lunaperche", "zaibatsu", "wildcharm", "sorbet", "vim", },
+  background = "dark",
   picker = {
     themes = {
       layout = "right",

--- a/lua/huez/config.lua
+++ b/lua/huez/config.lua
@@ -27,6 +27,7 @@ end
 ---@field theme_config_module? string
 ---@field exclude? string[]
 ---@field picker? Huez.Config.Pickers
+---@field background? "dark"|"light" -- preferred background setting
 
 ---@alias ThemeSetter fun(theme: string): boolean
 ---@class Huez.ThemeConfig
@@ -71,6 +72,9 @@ local DEFAULT_SETTINGS = {
     "sorbet",
     "vim",
   },
+
+  ---@type "dark"|"light"
+  background = "dark",
 
   ---@type Huez.Config.Pickers
   picker = {
@@ -195,7 +199,7 @@ M.set_theme = function(theme)
     return M.theme_setters[theme](theme)
   end
 
-  vim.cmd("set background=dark")
+  vim.cmd("set background=" .. M.current.background)
   local ok, _ = pcall(vim.cmd.colorscheme, theme)
 
   return ok


### PR DESCRIPTION
Currently, the background setting is hardcoded to dark, as referenced in [Issue #50](https://github.com/vague2k/huez.nvim/issues/50). For users who prefer light themes, there’s no built-in option to change the default background setting, limiting theme flexibility.

This PR introduces a configurable background option, allowing users to select either "dark" or "light" as their preferred background.